### PR TITLE
allow external_id in options to send notification

### DIFF
--- a/OneSignalTransport.php
+++ b/OneSignalTransport.php
@@ -71,7 +71,7 @@ final class OneSignalTransport extends AbstractTransport
 
         $recipientId = $message->getRecipientId() ?? $this->defaultRecipientId;
 
-        if (null === $recipientId) {
+        if (null === $recipientId && ($options['external_id'] ?? true)) {
             throw new LogicException(sprintf('The "%s" transport should have configured `defaultRecipientId` via DSN or provided with message options.', __CLASS__));
         }
 


### PR DESCRIPTION
Error thrown when we use external_id of OneSignal API ( usefull when we don't have device id and we want to send notification to a user ).